### PR TITLE
add: green triangle for absolidix link

### DIFF
--- a/app/app.web.view.css.ts
+++ b/app/app.web.view.css.ts
@@ -1,78 +1,75 @@
 namespace $.$$ {
+  $mol_style_define($optimade_cifplayer_app, {
+    contain: 'none', // otherwise in fullscreen 'fixed' positions plot relative to parent is not in the viewport
 
-	$mol_style_define( $optimade_cifplayer_app, {
+    '[mol_drop_status]': {
+      drag: {
+        Menu: {
+          background: {
+            color: $mol_theme.hover,
+          },
+        },
+      },
+    },
 
-		contain: 'none', // otherwise in fullscreen 'fixed' positions plot relative to parent is not in the viewport
+    Start: {
+      background: {
+        color: $mol_theme.back,
+      },
+      padding: {
+        top: '6rem',
+      },
+      flex: {
+        grow: 1,
+        direction: 'column',
+      },
+      align: {
+        items: 'center',
+      },
+    },
 
-		'[mol_drop_status]': {
-			drag: {
-				Menu: {
-					background: {
-						color: $mol_theme.hover,
-					},
-				},
-			},
-		},
+    Menu: {
+      Body_content: {
+        gap: $mol_gap.block,
+        maxWidth: '25rem',
+        flex: {
+          direction: 'row',
+        },
+      },
+      Head: {
+        justify: {
+          content: 'flex-start',
+        },
+      },
+    },
 
-		Start: {
-			background: {
-				color: $mol_theme.back,
-			},
-			padding: {
-				top: '6rem',
-			},
-			flex: {
-				grow: 1,
-				direction: 'column',
-			},
-			align: {
-				items: 'center',
-			},
-		},
+    Data_text: {
+      font: {
+        family: 'inherit',
+      },
+    },
 
-		Menu: {
-			Body_content: {
-				gap: $mol_gap.block,
-				maxWidth: '25rem',
-				flex: {
-					direction: 'row',
-				},
-			},
-			Head: {
-				justify: {
-					content: 'flex-start'
-				},
-			},
-		},
+    Body: {
+      flex: {
+        direction: 'column',
+        grow: 1,
+        shrink: 1,
+      },
+    },
 
-		Data_text: {
-			font: {
-				family: 'inherit',
-			},
-		},
+    Player: {
+      flex: {
+        grow: 1,
+        basis: '30rem',
+      },
+    },
 
-		Body: {
-			flex: { 
-				direction: 'column',
-				grow: 1,
-				shrink: 1,
-			},
-		},
-
-		Player: {
-			flex: {
-				grow: 1,
-				basis: '30rem',
-			},
-		},
-
-		Green_triangle_icon: {
-			position: "fixed",
-			bottom: "24px",
-			right: "24px",
-			fontSize: "32px",
-			color: 'green'
-		}
-	} )
-
+    Absolidix_link: {
+      position: 'fixed',
+      bottom: '24px',
+      right: '24px',
+      fontSize: '32px',
+      color: 'green',
+    },
+  });
 }

--- a/app/app.web.view.css.ts
+++ b/app/app.web.view.css.ts
@@ -66,6 +66,13 @@ namespace $.$$ {
 			},
 		},
 
+		Green_triangle_icon: {
+			position: "fixed",
+			bottom: "24px",
+			right: "24px",
+			fontSize: "32px",
+			color: 'green'
+		}
 	} )
 
 }

--- a/app/app.web.view.tree
+++ b/app/app.web.view.tree
@@ -40,3 +40,7 @@ $optimade_cifplayer_app $mol_drop
 			<= Paste_example $mol_button_minor
 				title \Show example
 				click? <=> paste_example? null
+			<= Green_triangle_icon $mol_link
+				uri \https://absolidix.com
+				sub /
+					<= Icon $mol_icon_play_outline

--- a/app/app.web.view.tree
+++ b/app/app.web.view.tree
@@ -40,7 +40,7 @@ $optimade_cifplayer_app $mol_drop
 			<= Paste_example $mol_button_minor
 				title \Show example
 				click? <=> paste_example? null
-			<= Green_triangle_icon $mol_link
+			<= Absolidix_link $mol_link
 				uri \https://absolidix.com
 				sub /
 					<= Icon $mol_icon_play_outline


### PR DESCRIPTION
To solve https://github.com/tilde-lab/cifplayer/issues/45 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces a new green triangle icon for the Absolidix link, enhancing the user interface. The icon is fixed at the bottom right of the screen and styled in green, with the application tree updated to include this link, improving user navigation.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>